### PR TITLE
Skip streams without urls.

### DIFF
--- a/resources/lib/stream.py
+++ b/resources/lib/stream.py
@@ -16,8 +16,9 @@ class Room(object):
     def __init__(self, json, group=''):
         self.streams = []
         for stream in json["streams"]:
-            for urlname, urldata in stream["urls"].items():
-                self.streams.append(Stream(urlname, urldata, stream))
+            if len(stream["urls"]) > 0:
+                for urlname, urldata in stream["urls"].items():
+                    self.streams.append(Stream(urlname, urldata, stream))
         self.slug = json["slug"]
         self.display = json["display"]
         if len(group) > 0:


### PR DESCRIPTION
Fix for #13 

- Live stream directory loads again. 
- All streams are shown. 
- When you try to play one of the non-public streams, you'll get the "The current talk is not being streamed." screen (just like in the browser).